### PR TITLE
allow equal stride and dimsize

### DIFF
--- a/xbatcher/generators.py
+++ b/xbatcher/generators.py
@@ -19,7 +19,7 @@ def _slices(dimsize, size, overlap=0):
     slices = []
     stride = size - overlap
     assert stride > 0
-    assert stride < dimsize
+    assert stride <= dimsize
     for start in range(0, dimsize, stride):
         end = start + size
         if end <= dimsize:


### PR DESCRIPTION
The current assertion breaks if we want to get 1 sample per batch (where the input dims and output dims are identical). Changing < to <= to allow such cases.