### PR TITLE
Batches to zarr

### DIFF
--- a/xbatcher/tests/test_to_zarr.py
+++ b/xbatcher/tests/test_to_zarr.py
@@ -1,0 +1,34 @@
+import xarray as xr
+import numpy as np
+import tempfile
+import xbatcher
+
+
+def test_to_zarr():
+    da = xr.DataArray(
+        np.random.rand(1000, 100, 100), name="foo", dims=["time", "y", "x"]
+    ).chunk({"time": 1})
+
+    bgen = xbatcher.BatchGenerator(da, {"time": 10}, preload_batch=False)
+
+    for ds_batch in bgen:
+        ds_first_batch = ds_batch
+        break
+
+    tempdir = tempfile.TemporaryDirectory().name
+    # with tempfile.TemporaryDirectory() as tempdir:
+    bgen.to_zarr(tempdir)
+
+    bgen_loaded = xbatcher.BatchGenerator.from_zarr(tempdir)
+
+    for loaded_batch in bgen_loaded:
+        loaded_first_batch = loaded_batch
+        break
+
+    # DataArray.equals doesn't work while the DataArray's are still stacked
+    da_first_batch = ds_first_batch.unstack()
+    da_loaded_first_batch = loaded_first_batch.unstack()
+    # For some reason DataArray.equals doesn't work here, but DataArray.broadcast_equals did
+    assert da_loaded_first_batch.broadcast_equals(da_first_batch)
+    # I think this should mean that DataArray.equals should work
+    assert (da_loaded_first_batch - da_first_batch).max() == 0.0

--- a/xbatcher/tests/test_to_zarr.py
+++ b/xbatcher/tests/test_to_zarr.py
@@ -16,7 +16,6 @@ def test_to_zarr():
         break
 
     tempdir = tempfile.TemporaryDirectory().name
-    # with tempfile.TemporaryDirectory() as tempdir:
     bgen.to_zarr(tempdir)
 
     bgen_loaded = xbatcher.BatchGenerator.from_zarr(tempdir)


### PR DESCRIPTION
Add `BatchGenerator.to_zarr` and `BatchGenerator.from_zarr` to make it possible to save generated batches to zarr and later load them from zarr. By chunking along the batch dimension this enables fast data-loading at training time.