### PR TITLE
Fix loader docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@ coverage.xml
 
 # Sphinx documentation
 doc/_build/
-doc/generated
+doc/generated/
 
 # PyBuilder
 target/

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
-doc/_build/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -52,7 +51,8 @@ coverage.xml
 *.log
 
 # Sphinx documentation
-docs/_build/
+doc/_build/
+doc/generated
 
 # PyBuilder
 target/

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -48,6 +48,7 @@ help:
 
 clean:
 	rm -rf $(BUILDDIR)/*
+	rm -rf generated/*
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.7
+  - python=3.8
   - dask
   - docrep
   - ipython
@@ -12,8 +12,10 @@ dependencies:
   - numpy
   - numpydoc
   - pytest
+  - pytorch
   - sphinx
   - sphinx-autosummary-accessors
   - sphinx-copybutton
+  - sphinx_rtd_theme
   - xarray
   - pip


### PR DESCRIPTION
The docs for the PyTorch data loaders aren't currently rendered at https://xbatcher.readthedocs.io/en/latest/api.html#dataloaders due to the following exception:
```
WARNING: autodoc: failed to import class 'torch.MapDataset' from module 'xbatcher.loaders'; the following exception was raised:
No module named 'torch'
WARNING: autodoc: failed to import class 'torch.IterableDataset' from module 'xbatcher.loaders'; the following exception was raised:
No module named 'torch'
```

This PR adds pytorch to `doc/environment.yml` to fix that problem. It also makes two minor changes - 
- add `sphinx_rtd_theme` to `doc/environment.yml` so that the same file can be used by contributors to set up an environment and build the docs locally.
- ignore and clean the folder `doc/generated/`, which contains built html files for the xarray accessors.