### PR TITLE
Let torch accessor and dataloader handle either xarray.DataArray or xarray.Dataset inputs

### DIFF
--- a/xbatcher/accessors.py
+++ b/xbatcher/accessors.py
@@ -27,15 +27,32 @@ class BatchAccessor:
 
 
 @xr.register_dataarray_accessor('torch')
+@xr.register_dataset_accessor('torch')
 class TorchAccessor:
     def __init__(self, xarray_obj):
         self._obj = xarray_obj
+
+    def _as_xarray_dataarray(self, xr_obj):
+        """
+        Convert xarray.Dataset to xarray.DataArray if needed, so that it can
+        be converted into a torch.Tensor object.
+        """
+        try:
+            # Convert xr.Dataset to xr.DataArray
+            dataarray = xr_obj.to_array()
+        except AttributeError:  # 'DataArray' object has no attribute 'to_array'
+            # If object is already an xr.DataArray
+            dataarray = xr_obj
+
+        return dataarray
 
     def to_tensor(self):
         """Convert this DataArray to a torch.Tensor"""
         import torch
 
-        return torch.tensor(self._obj.data)
+        dataarray = self._as_xarray_dataarray(self._obj)
+
+        return torch.tensor(data=dataarray.data)
 
     def to_named_tensor(self):
         """
@@ -45,4 +62,6 @@ class TorchAccessor:
         """
         import torch
 
-        return torch.tensor(self._obj.data, names=tuple(self._obj.sizes))
+        dataarray = self._as_xarray_dataarray(self._obj)
+
+        return torch.tensor(data=dataarray.data, names=tuple(dataarray.sizes))

--- a/xbatcher/accessors.py
+++ b/xbatcher/accessors.py
@@ -39,7 +39,7 @@ class TorchAccessor:
         """
         try:
             # Convert xr.Dataset to xr.DataArray
-            dataarray = xr_obj.to_array()
+            dataarray = xr_obj.to_array().squeeze(dim='variable')
         except AttributeError:  # 'DataArray' object has no attribute 'to_array'
             # If object is already an xr.DataArray
             dataarray = xr_obj
@@ -50,7 +50,7 @@ class TorchAccessor:
         """Convert this DataArray to a torch.Tensor"""
         import torch
 
-        dataarray = self._as_xarray_dataarray(self._obj)
+        dataarray = self._as_xarray_dataarray(xr_obj=self._obj)
 
         return torch.tensor(data=dataarray.data)
 
@@ -62,6 +62,6 @@ class TorchAccessor:
         """
         import torch
 
-        dataarray = self._as_xarray_dataarray(self._obj)
+        dataarray = self._as_xarray_dataarray(xr_obj=self._obj)
 
         return torch.tensor(data=dataarray.data, names=tuple(dataarray.sizes))

--- a/xbatcher/tests/test_accessors.py
+++ b/xbatcher/tests/test_accessors.py
@@ -40,23 +40,41 @@ def test_batch_accessor_da(sample_ds_3d):
         assert batch_class.equals(batch_acc)
 
 
-def test_torch_to_tensor(sample_ds_3d):
+@pytest.mark.parametrize(
+    'foo_var',
+    [
+        'foo',  # xr.DataArray
+        ['foo'],  # xr.Dataset
+    ],
+)
+def test_torch_to_tensor(sample_ds_3d, foo_var):
     torch = pytest.importorskip('torch')
 
-    da = sample_ds_3d['foo']
-    t = da.torch.to_tensor()
+    foo = sample_ds_3d[foo_var]
+    t = foo.torch.to_tensor()
     assert isinstance(t, torch.Tensor)
     assert t.names == (None, None, None)
-    assert t.shape == da.shape
-    np.testing.assert_array_equal(t, da.values)
+    assert t.shape == tuple(foo.sizes.values())
+
+    foo_array = foo.to_array().squeeze() if hasattr(foo, 'to_array') else foo
+    np.testing.assert_array_equal(t, foo_array.values)
 
 
-def test_torch_to_named_tensor(sample_ds_3d):
+@pytest.mark.parametrize(
+    'foo_var',
+    [
+        'foo',  # xr.DataArray
+        ['foo'],  # xr.Dataset
+    ],
+)
+def test_torch_to_named_tensor(sample_ds_3d, foo_var):
     torch = pytest.importorskip('torch')
 
-    da = sample_ds_3d['foo']
-    t = da.torch.to_named_tensor()
+    foo = sample_ds_3d[foo_var]
+    t = foo.torch.to_named_tensor()
     assert isinstance(t, torch.Tensor)
-    assert t.names == da.dims
-    assert t.shape == da.shape
-    np.testing.assert_array_equal(t, da.values)
+    assert t.names == tuple(foo.dims)
+    assert t.shape == tuple(foo.sizes.values())
+
+    foo_array = foo.to_array().squeeze() if hasattr(foo, 'to_array') else foo
+    np.testing.assert_array_equal(t, foo_array.values)

--- a/xbatcher/tests/test_torch_loaders.py
+++ b/xbatcher/tests/test_torch_loaders.py
@@ -61,22 +61,22 @@ def test_map_dataset(ds_xy, x_var, y_var):
     assert len(dataset) == len(x_gen)
 
     # test integration with torch DataLoader
-    loader = torch.utils.data.DataLoader(dataset)
+    loader = torch.utils.data.DataLoader(dataset, batch_size=None)
 
     for x_batch, y_batch in loader:
-        assert x_batch.shape == (1, 10, 5)
-        assert y_batch.shape == (1, 10)
+        assert x_batch.shape == (10, 5)
+        assert y_batch.shape == (10,)
         assert isinstance(x_batch, torch.Tensor)
 
-    # TODO: why does pytorch add an extra dimension (length 1) to x_batch
-    assert tuple(x_gen[-1].sizes.values()) == x_batch.shape[1:]
+    # Check that array shape of last item in generator is same as the batch image
+    assert tuple(x_gen[-1].sizes.values()) == x_batch.shape
     # Check that array values from last item in generator and batch are the same
     gen_array = (
         x_gen[-1].to_array().squeeze()
         if hasattr(x_gen[-1], 'to_array')
         else x_gen[-1]
     )
-    np.testing.assert_array_equal(gen_array, x_batch[0, :, :])
+    np.testing.assert_array_equal(gen_array, x_batch)
 
 
 @pytest.mark.parametrize(
@@ -129,19 +129,19 @@ def test_iterable_dataset(ds_xy, x_var, y_var):
     dataset = IterableDataset(x_gen, y_gen)
 
     # test integration with torch DataLoader
-    loader = torch.utils.data.DataLoader(dataset)
+    loader = torch.utils.data.DataLoader(dataset, batch_size=None)
 
     for x_batch, y_batch in loader:
-        assert x_batch.shape == (1, 10, 5)
-        assert y_batch.shape == (1, 10)
+        assert x_batch.shape == (10, 5)
+        assert y_batch.shape == (10,)
         assert isinstance(x_batch, torch.Tensor)
 
-    # TODO: why does pytorch add an extra dimension (length 1) to x_batch
-    assert tuple(x_gen[-1].sizes.values()) == x_batch.shape[1:]
+    # Check that array shape of last item in generator is same as the batch image
+    assert tuple(x_gen[-1].sizes.values()) == x_batch.shape
     # Check that array values from last item in generator and batch are the same
     gen_array = (
         x_gen[-1].to_array().squeeze()
         if hasattr(x_gen[-1], 'to_array')
         else x_gen[-1]
     )
-    np.testing.assert_array_equal(gen_array, x_batch[0, :, :])
+    np.testing.assert_array_equal(gen_array, x_batch)

--- a/xbatcher/tests/test_torch_loaders.py
+++ b/xbatcher/tests/test_torch_loaders.py
@@ -24,10 +24,17 @@ def ds_xy():
     return ds
 
 
-def test_map_dataset(ds_xy):
+@pytest.mark.parametrize(
+    ('x_var', 'y_var'),
+    [
+        ('x', 'y'),  # xr.DataArray
+        (['x'], ['y']),  # xr.Dataset
+    ],
+)
+def test_map_dataset(ds_xy, x_var, y_var):
 
-    x = ds_xy['x']
-    y = ds_xy['y']
+    x = ds_xy[x_var]
+    y = ds_xy[y_var]
 
     x_gen = BatchGenerator(x, {'sample': 10})
     y_gen = BatchGenerator(y, {'sample': 10})
@@ -62,15 +69,27 @@ def test_map_dataset(ds_xy):
         assert isinstance(x_batch, torch.Tensor)
 
     # TODO: why does pytorch add an extra dimension (length 1) to x_batch
-    assert x_gen[-1].shape == x_batch.shape[1:]
-    # TODO: add test for xarray.Dataset
-    assert np.array_equal(x_gen[-1], x_batch[0, :, :])
+    assert tuple(x_gen[-1].sizes.values()) == x_batch.shape[1:]
+    # Check that array values from last item in generator and batch are the same
+    gen_array = (
+        x_gen[-1].to_array().squeeze()
+        if hasattr(x_gen[-1], 'to_array')
+        else x_gen[-1]
+    )
+    np.testing.assert_array_equal(gen_array, x_batch[0, :, :])
 
 
-def test_map_dataset_with_transform(ds_xy):
+@pytest.mark.parametrize(
+    ('x_var', 'y_var'),
+    [
+        ('x', 'y'),  # xr.DataArray
+        (['x'], ['y']),  # xr.Dataset
+    ],
+)
+def test_map_dataset_with_transform(ds_xy, x_var, y_var):
 
-    x = ds_xy['x']
-    y = ds_xy['y']
+    x = ds_xy[x_var]
+    y = ds_xy[y_var]
 
     x_gen = BatchGenerator(x, {'sample': 10})
     y_gen = BatchGenerator(y, {'sample': 10})
@@ -92,10 +111,17 @@ def test_map_dataset_with_transform(ds_xy):
     assert (y_batch == -1).all()
 
 
-def test_iterable_dataset(ds_xy):
+@pytest.mark.parametrize(
+    ('x_var', 'y_var'),
+    [
+        ('x', 'y'),  # xr.DataArray
+        (['x'], ['y']),  # xr.Dataset
+    ],
+)
+def test_iterable_dataset(ds_xy, x_var, y_var):
 
-    x = ds_xy['x']
-    y = ds_xy['y']
+    x = ds_xy[x_var]
+    y = ds_xy[y_var]
 
     x_gen = BatchGenerator(x, {'sample': 10})
     y_gen = BatchGenerator(y, {'sample': 10})
@@ -111,6 +137,11 @@ def test_iterable_dataset(ds_xy):
         assert isinstance(x_batch, torch.Tensor)
 
     # TODO: why does pytorch add an extra dimension (length 1) to x_batch
-    assert x_gen[-1].shape == x_batch.shape[1:]
-    # TODO: add test for xarray.Dataset
-    assert np.array_equal(x_gen[-1], x_batch[0, :, :])
+    assert tuple(x_gen[-1].sizes.values()) == x_batch.shape[1:]
+    # Check that array values from last item in generator and batch are the same
+    gen_array = (
+        x_gen[-1].to_array().squeeze()
+        if hasattr(x_gen[-1], 'to_array')
+        else x_gen[-1]
+    )
+    np.testing.assert_array_equal(gen_array, x_batch[0, :, :])


### PR DESCRIPTION
**Description of proposed changes**

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Convert xarray.Dataset to xarray.DataArray first, so that the `.data` method works to get the underlying array which can be converted to a torch.Tensor. Also added parametrized unit tests, only for the 2D ('x', 'y') case for both `xarray.DataArray` and `xarray.Dataset`.

TODO:
- [x] Preliminary support in `.torch` accessor to convert `xarray.Dataset` directly to `torch.Tensor`
- [x] Add parametrized unit tests for `xarray.Dataset` and `xarray.DataArray` inputs
  - [x] In the DataLoader `xbatcher/loaders/torch.py`
  - [x] In the xarray accessors `xbatcher/accessor.py`

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->

Fixes #84, continuation of #71